### PR TITLE
Create .timewsync folder, if it doesn't exist

### DIFF
--- a/timewsync/__init__.py
+++ b/timewsync/__init__.py
@@ -40,7 +40,7 @@ from timewsync.dispatch import ServerError, dispatch
 from timewsync.file_parser import as_interval_list, as_file_strings, extract_tags
 from timewsync.io_handler import read_data, read_keys, write_data, write_keys, delete_snapshot
 from timewsync.config import NoConfigurationFileError, MissingSectionError, MissingConfigurationError, Configuration, \
-    create_example_configuration
+    create_example_configuration, ensure_data_dir_exists
 from timewsync.logging_helpers import MinMaxLevelFilter
 
 DEFAULT_DATA_DIR = os.path.join("~", ".timewsync")
@@ -120,6 +120,8 @@ def main():
         debug_handler.addFilter(MinMaxLevelFilter(logging.DEBUG, logging.INFO))
         debug_handler.setFormatter(debug_formatter)
         log.addHandler(debug_handler)
+
+    ensure_data_dir_exists(data_dir)
 
     try:
         configuration = Configuration.read(data_dir)

--- a/timewsync/config.py
+++ b/timewsync/config.py
@@ -133,20 +133,27 @@ class Configuration:
 
 
 def create_example_configuration(data_dir: str) -> str:
-    """Writes an example configuration to the data directory
+    """Writes an example configuration to the data directory.
 
     Args:
-        data_dir: The path to the timewsync data directory
+        data_dir: The path to the timewsync data directory.
 
     Returns:
-        The path to the configuration file
+        The path to the configuration file.
     """
-    data_folder = Path(data_dir)
-    data_folder.mkdir(parents=True, exist_ok=True)
-
     path = os.path.join(data_dir, CONFIGURATION_FILE_NAME)
 
     with open(path, "w") as file:
         file.write(EXAMPLE_CONFIGURATION)
 
     return path
+
+
+def ensure_data_dir_exists(data_dir: str) -> None:
+    """Creates a folder at data_dir location, if it doesn't exist already.
+
+    Args:
+        data_dir: The path to the timewsync data directory.
+    """
+    data_folder = Path(data_dir)
+    data_folder.mkdir(parents=True, exist_ok=True)

--- a/timewsync/config.py
+++ b/timewsync/config.py
@@ -27,6 +27,7 @@
 
 import configparser
 import os
+from pathlib import Path
 
 CONFIGURATION_FILE_NAME = "timewsync.conf"
 EXAMPLE_CONFIGURATION = """
@@ -140,6 +141,9 @@ def create_example_configuration(data_dir: str) -> str:
     Returns:
         The path to the configuration file
     """
+    data_folder = Path(data_dir)
+    data_folder.mkdir(parents=True, exist_ok=True)
+
     path = os.path.join(data_dir, CONFIGURATION_FILE_NAME)
 
     with open(path, "w") as file:


### PR DESCRIPTION
As described in #5, we currently print a stacktrace, if the `.timewsync` directory doesn't exist.
This commit modifies `config.create_example_configuration` to create the folder, if necessacy.

Fixes: #5
