### PR TITLE
Fix clients ignoring deletions that result in empty months, among smaller bugs

### DIFF
--- a/timewsync/__init__.py
+++ b/timewsync/__init__.py
@@ -237,7 +237,10 @@ def sync(configuration: Configuration) -> None:
     print("Synchronization successful!", file=sys.stderr)
 
     if active_interval and not started_tracking:
-        log.warning("Warning: Cannot restart time tracking because there exists a time interval in the future!")
+        log.warning(
+            "Warning: Cannot restart time tracking because there exists a time interval in the future "
+            "which would overlap with the open interval!"
+        )
 
 
 def _generate_key(data_dir: str) -> None:

--- a/timewsync/__init__.py
+++ b/timewsync/__init__.py
@@ -238,7 +238,7 @@ def sync(configuration: Configuration) -> None:
 
     if active_interval and not started_tracking:
         log.warning(
-            "Warning: Cannot restart time tracking because there exists a time interval in the future "
+            "Cannot restart time tracking because there exists a time interval in the future "
             "which would overlap with the open interval!"
         )
 

--- a/timewsync/__init__.py
+++ b/timewsync/__init__.py
@@ -184,6 +184,10 @@ def sync(configuration: Configuration) -> None:
         log.error("Unexpected error occurred during JWT generation. No changes were made.")
         return
 
+    # Active time tracking
+    if active_interval:
+        print("Time tracking is active. Stopped and restarted time tracking to prevent conflicts.", file=sys.stderr)
+
     # Communicate with server
     try:
         response_intervals, conflict_flag = dispatch(configuration, timew_intervals, snapshot_intervals, token)
@@ -230,19 +234,10 @@ def sync(configuration: Configuration) -> None:
             log.error("Error occurred while executing the conflict-occurred hook. Continuing...")
 
     # Output
-    if active_interval:
-        print("Time tracking is active. Stopped time tracking.", file=sys.stderr)
-
     print("Synchronization successful!", file=sys.stderr)
 
-    if active_interval:
-        if started_tracking:
-            print("Restarted time tracking.", file=sys.stderr)
-        else:
-            log.warning(
-                "Warning: Cannot restart time tracking! This error occured because there exists "
-                "an interval in the future which would overlap with the open interval."
-            )
+    if active_interval and not started_tracking:
+        log.warning("Warning: Cannot restart time tracking because there exists a time interval in the future!")
 
 
 def _generate_key(data_dir: str) -> None:

--- a/timewsync/io_handler.py
+++ b/timewsync/io_handler.py
@@ -149,6 +149,11 @@ def _write_intervals(monthly_data: Dict[str, str]):
     # Create data directory if not present
     os.makedirs(DATA_FOLDER, exist_ok=True)
 
+    # Remove previous data
+    for file_name in os.listdir(Path(DATA_FOLDER)):
+        if re.fullmatch(DATAFILE_REGEX, file_name):
+            os.remove(os.path.join(DATA_FOLDER, file_name))
+
     # Write data to files
     for file_name, data in monthly_data.items():
         with open(os.path.join(DATA_FOLDER, file_name), "w") as file:

--- a/timewsync/io_handler.py
+++ b/timewsync/io_handler.py
@@ -35,6 +35,7 @@ from jwcrypto.jwk import JWK
 
 TIMEW_FOLDER = os.path.expanduser(os.environ.get("TIMEWARRIORDB", os.path.join("~", ".timewarrior")))
 DATA_FOLDER = os.path.join(TIMEW_FOLDER, "data")
+DATAFILE_REGEX = r"^\d\d\d\d-\d\d\.data$"
 
 
 def read_data(timewsync_data_dir: str) -> Tuple[Dict[str, str], Dict[str, str]]:
@@ -63,7 +64,7 @@ def _read_intervals() -> Dict[str, str]:
     if os.path.exists(DATA_FOLDER):
 
         # Identify all data sources
-        file_list = [f for f in os.listdir(Path(DATA_FOLDER)) if (re.search(r"^\d\d\d\d-\d\d\.data$", f))]
+        file_list = [f for f in os.listdir(Path(DATA_FOLDER)) if (re.fullmatch(DATAFILE_REGEX, f))]
 
         # Read all file contents
         for file_name in file_list:
@@ -145,7 +146,7 @@ def _write_intervals(monthly_data: Dict[str, str]):
     Args:
         monthly_data: A dictionary containing the file names and corresponding data for every month.
     """
-    # Find data directory, create if not present
+    # Create data directory if not present
     os.makedirs(DATA_FOLDER, exist_ok=True)
 
     # Write data to files


### PR DESCRIPTION
### Clients ignoring deletions
Clients only overwrite data files when new data arrives.
They ignore files for which no data arrives, even though that is used to signal that the data for that file has been deleted completely.
Now, all data files are deleted before getting rebuild, ensuring that only the data present on the server is present on the client (aside from a possible open interval).

### Notification for active tracking
The notification for active time tracking is rephrased and moved, as to not give the impression that there was a gap and to hint at possible conflicts between open and closed intervals.

### Ignoring invalid data sources
When collecting data source files, `re.search` is replaced by `re.fullmatch` to ensure that only valid files (`YYYY-MM.data`) are included.
This should prevent similarly-named files (e.g. `2024-02.data.bak`) from being collected and/or deleted.