### PR TITLE
Trigger publish action on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Publish on PyPI
 
 on:
   release:
-    types: [created]
+    types: [released]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `created` event is not triggered if the release is first created as a draft and then released. The `released` event seems to better fit our desired behavior.

Reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release