### PR TITLE
Makes Readme a bit more explicit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ in the data directory under `$TIMEWSYNC/private_key.pem` and
 `$TIMEWSYNC/public_key.pem`. The key pair can be generated using the
 `generate-keys` subcommand.
 
+#### Synchronization
+
+After setting up [timew-sync-server](https://github.com/timewarrior-synchronize/timew-sync-server), and adding two or more clients to an id
+corresponding to a single user, you can track your time normally using 
+`timew` commands and when you want to synchronize, run `timewsync`.
+
+
 #### Hooks
 
 Hooks are special files located in the data directory which will be


### PR DESCRIPTION
I added a line to make it more clear that each client that belongs to a user has the same user id, and that not each client gets its own id. Also, I added that one needs to also set up timew-sync-server.
Maybe it's obvious to developers, but it wasn't obvious to me, so I think this might help.